### PR TITLE
puppet-lint 2.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 ---
 language: ruby
+sudo: false
+cache: bundler
 bundler_args: "--without system"
 script: "bundle exec rake spec"
 notifications:
   email: false
 rvm:
-  - "2.0.0"
   - "1.9.3"
-  - "1.8.7"
+  - "2.0.0"
+  - "2.1.5"

--- a/puppet-lint-numeric_variable.gemspec
+++ b/puppet-lint-numeric_variable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-numericvariable'
-  spec.version     = '1.0.0'
+  spec.version     = '1.0.1'
   spec.homepage    = 'https://github.com/fiddyspence/puppetlint-numericvariable'
   spec.license     = 'MIT'
   spec.author      = 'Chris Spence'
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     Extends puppet-lint to ensure that your variables are not numeric
   EOF
 
-  spec.add_dependency             'puppet-lint', '~> 1.0'
+  spec.add_dependency             'puppet-lint', '>= 1.0', '< 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
@fiddyspence Had to do some cleanup for travis tests to pass as well. If you can publish this to rubygems afterward that would be awesome, to let people leverage the new puppet-lint 2.0.0 release. Thanks!
