### PR TITLE
Fix puppet-lint dependency version

### DIFF
--- a/puppet-lint-numeric_variable.gemspec
+++ b/puppet-lint-numeric_variable.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     Extends puppet-lint to ensure that your variables are not numeric
   EOF
 
-  spec.add_dependency             'puppet-lint', '~> 1.0', '< 3.0'
+  spec.add_dependency             'puppet-lint', '>= 1.0', '< 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
This would never match any thing greater than 1.x

`rake spec` runs clean with puppet-lint 2.3.0